### PR TITLE
Add use shortcut

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -30,6 +30,7 @@ class ServerModule extends AbstractModule {
     this.expressApp = express();
     // reference to the HTTP server
     let httpServer;
+    this.use = this.expressApp.use.bind(this.expressApp);
     /**
     * The default/'root' router for the application
     * @type {Router}


### PR DESCRIPTION
Adds a use shortcut so that other modules can do (things like):

`app.getModule('server').use(bodyParser.json({ limit: '5mb' }));`

Use is listed in the express docs http://expressjs.com/en/4x/api.html#app.use