### PR TITLE
Fix: correct API map grouping and route it through auth

### DIFF
--- a/lib/ServerModule.js
+++ b/lib/ServerModule.js
@@ -2,6 +2,7 @@ import express from 'express'
 import { AbstractModule, Hook } from 'adapt-authoring-core'
 import Router from './Router.js'
 import ServerUtils from './ServerUtils.js'
+import { mapHandler } from './utils/mapHandler.js'
 /**
  * Adds an Express server to the authoring tool
  * @memberof server
@@ -20,7 +21,21 @@ class ServerModule extends AbstractModule {
      * @type {Router}
      */
     this.api = new Router('/api', this.expressApp, [], [ServerUtils.debugRequestTime])
-    this.api.expressRouter.get('/', (req, res) => res.json(this.api?.map))
+    this.api.addRoute({
+      route: '/',
+      handlers: { get: mapHandler(this.api) },
+      meta: {
+        get: {
+          summary: 'Retrieve a map of the available API endpoints',
+          responses: {
+            200: {
+              description: 'The API endpoint map',
+              content: { 'application/json': { schema: { type: 'object' } } }
+            }
+          }
+        }
+      }
+    })
     /**
      * The default/'root' router for the application
      * @type {Router}

--- a/lib/utils/generateRouterMap.js
+++ b/lib/utils/generateRouterMap.js
@@ -32,7 +32,7 @@ function getEndpoints (r) {
 /** @ignore */
 function getRelativeRoute (relFrom, relTo) {
   if (relFrom === relTo) {
-    return `${relFrom.route}_`
+    return 'general_'
   }
   let route = ''
   for (let r = relTo; r !== relFrom; r = r.parentRouter) route = `${r.root}_${route}`

--- a/tests/utils-generateRouterMap.spec.js
+++ b/tests/utils-generateRouterMap.spec.js
@@ -42,7 +42,6 @@ describe('generateRouterMap()', () => {
   it('should include endpoint URLs and accepted methods', () => {
     const mockRouter = {
       root: 'api',
-      route: '/api',
       path: '/api',
       url: 'http://localhost:5000/api',
       routes: [
@@ -59,6 +58,7 @@ describe('generateRouterMap()', () => {
     const keys = Object.keys(map)
 
     assert.ok(keys.length > 0)
+    assert.equal(keys[0], 'general_endpoints')
     const endpoints = map[keys[0]]
     assert.ok(Array.isArray(endpoints))
     assert.equal(endpoints[0].url, 'http://localhost:5000/api/users')
@@ -81,7 +81,6 @@ describe('generateRouterMap()', () => {
     }
     const mockRouter = {
       root: 'api',
-      route: '/api',
       path: '/api',
       url: 'http://localhost:5000/api',
       routes: [],
@@ -117,7 +116,6 @@ describe('generateRouterMap()', () => {
     }
     const mockRouter = {
       root: 'api',
-      route: '/api',
       path: '/api',
       url: 'http://localhost:5000/api',
       routes: [],


### PR DESCRIPTION
### Fixes #68

### Fix
- `getRelativeRoute` (`lib/utils/generateRouterMap.js`) referenced `relFrom.route`, which does not exist on `Router` (only `.root`), so routes attached directly to `/api` were grouped under the literal key `undefined_endpoints`. They are now grouped under `general_endpoints`, keeping their URLs (`/api/config`, `/api/lang/:lang`) unchanged.
- The `GET /api` endpoint map was served via a raw `expressRouter.get("/", …)` that bypassed the router handler-middleware chain (so it could not be secured). It is now registered as a proper route via `addRoute` — using the existing `mapHandler` util — so it passes through the auth chain, with OpenAPI `meta` so the map self-documents.

### Testing
- Updated `tests/utils-generateRouterMap.spec.js`: removed the fake `.route` from mocks (which masked the bug) and asserted the top-level key is `general_endpoints`.
- `npx standard` clean; `npm test` 137/137 passing.
- Verified live alongside adapt-security/adapt-authoring-auth#90: `GET /api` returns 401 when unauthenticated; `/api/config` and `/api/lang/en` remain public.