### PR TITLE
Fix: mark /api responses private to bar shared caching (fixes #71)

### DIFF
--- a/docs/server-requests.md
+++ b/docs/server-requests.md
@@ -70,6 +70,19 @@ This may go without saying, but please stick to standardised HTTP response codes
 
 See the [Mozilla Developer Network docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) for a full list of HTTP response status codes and what they mean.
 
+## Response caching
+
+Every `/api` response is sent with `Cache-Control: private, no-cache` by default. API responses vary by the caller's authentication, but a shared cache (a CDN or proxy) keys on the URL and ignores the session cookie — so without this a shared cache could store one user's response and serve it to another. `private` keeps shared caches out while still allowing the caller's own browser cache and ETag revalidation; `no-cache` makes the browser revalidate rather than serve a stale copy.
+
+If an endpoint is genuinely public and user-agnostic (e.g. a static reference resource), a handler may override this by setting its own `Cache-Control` before responding:
+
+```js
+async myPublicHandler (req, res) {
+  res.set('Cache-Control', 'public, max-age=3600')
+  res.json(data)
+}
+```
+
 ## Use the built-in error handler
 The Server module adds a `sendError` utility function to the ServerResponse object that's passed to every route handler in the stack. Making use of this in your own code will ensure errors are formatted in a consistent way.
 

--- a/lib/ServerModule.js
+++ b/lib/ServerModule.js
@@ -20,7 +20,7 @@ class ServerModule extends AbstractModule {
      * The router responsible for handling all APIs
      * @type {Router}
      */
-    this.api = new Router('/api', this.expressApp, [], [ServerUtils.debugRequestTime])
+    this.api = new Router('/api', this.expressApp, [], [ServerUtils.setDefaultCacheControl, ServerUtils.debugRequestTime])
     this.api.addRoute({
       route: '/',
       handlers: { get: mapHandler(this.api) },

--- a/lib/ServerUtils.js
+++ b/lib/ServerUtils.js
@@ -114,6 +114,24 @@ class ServerUtils {
   }
 
   /**
+   * Marks API responses as privately cacheable only. API responses are
+   * request-specific (they vary by the caller's authentication), but the cache
+   * key of a shared cache — a CDN or proxy — is URL-based and ignores the
+   * session cookie, so without this a shared cache can store one user's response
+   * and serve it to another. `private` keeps such caches out while still
+   * allowing the caller's own browser cache and ETag revalidation; `no-cache`
+   * makes the browser revalidate rather than serve a stale response. A handler
+   * may override this for a genuinely public, user-agnostic endpoint.
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {Function} next
+   */
+  static setDefaultCacheControl (req, res, next) {
+    res.set('Cache-Control', 'private, no-cache')
+    next()
+  }
+
+  /**
    * Handles restriction of routes marked as internal
    * @param {external:ExpressRequest} req
    * @param {external:ExpressResponse} res

--- a/tests/ServerUtils.spec.js
+++ b/tests/ServerUtils.spec.js
@@ -247,4 +247,18 @@ describe('ServerUtils', () => {
       assert.equal(nextArg.code, 'ENDPOINT_NOT_FOUND')
     })
   })
+
+  describe('#setDefaultCacheControl()', () => {
+    it('should mark the response private + no-cache and call next', () => {
+      let headerName, headerValue
+      let nextCalled = false
+      const res = { set: (name, value) => { headerName = name; headerValue = value } }
+
+      ServerUtils.setDefaultCacheControl({}, res, () => { nextCalled = true })
+
+      assert.equal(headerName, 'Cache-Control')
+      assert.equal(headerValue, 'private, no-cache')
+      assert.equal(nextCalled, true)
+    })
+  })
 })


### PR DESCRIPTION
### Fixes #71

### Fix

- Default every `/api` response to `Cache-Control: private, no-cache` via a new `ServerUtils.setDefaultCacheControl` middleware wired into the top-level `/api` router (so it covers all child routers). API responses vary by the caller's authentication, but a shared cache (CDN/proxy) keys on the URL and ignores the session cookie — without this a shared cache could store one user's response and serve it to another (observed as a logged-out user coming back authenticated as a different user behind a caching CDN). `private` keeps shared caches out; `no-cache` makes the browser revalidate. `no-store` was deliberately avoided so the browser cache and the UI's ETag revalidation (e.g. `/content/tree`) keep working. A handler may override the default for a genuinely public, user-agnostic endpoint.

### Docs

- `server-requests.md`: new "Response caching" section documenting the default and how to override it.

### Testing

- Added a `ServerUtils.spec.js` case asserting the middleware sets `Cache-Control: private, no-cache` and calls `next`.
- Full module suite passes (32/32); `standard` clean.
- Verified the parent-`/api` middleware header propagates to a child-router JSON response and is present on the conditional (ETag) follow-up, and confirmed the origin currently emits an ETag with no `Cache-Control`.

### Note

A CDN "cache everything" rule can override origin cache headers, so deployments behind a CDN should also ensure `/api/*` is bypassed (or that origin cache-control is respected). This origin header is the deployment-independent defence.
